### PR TITLE
Add tests to reforms

### DIFF
--- a/Simulation_engine/reforms.py
+++ b/Simulation_engine/reforms.py
@@ -1,177 +1,119 @@
-def bareme(args: tuple) -> tuple:
-    parameters, dir, instant, reform_period, verbose = args
+from typing import Callable, NamedTuple, TypeVar
 
-    dirb = dir["bareme"]
-    seuils = dirb["seuils"]
-    taux = dirb["taux"]
-    if verbose:
-        print("bareme avant modif :")
-        print(parameters.impot_revenu.bareme.get_at_instant(instant))
-    for i in range(len(seuils)):
-        parameters.impot_revenu.bareme.brackets[i].threshold.update(
-            period=reform_period, value=seuils[i]
-        )
-        parameters.impot_revenu.bareme.brackets[i].rate.update(
-            period=reform_period, value=taux[i] * 0.01
-        )
+from toolz.functoolz import compose  # type: ignore
 
-    for i in range(len(seuils), 15):
-        try:
-            parameters.impot_revenu.bareme.brackets[i].threshold.update(
-                period=reform_period, value=seuils[-1] + i
-            )
-            parameters.impot_revenu.bareme.brackets[i].rate.update(
-                period=reform_period, value=taux[-1] * 0.01
-            )
-        except (Exception):
-            break
+from openfisca_core.parameters import ParameterNode  # type: ignore
+from openfisca_core import periods  # type: ignore
 
-    if verbose:
-        print("bareme après modif :")
-        print(parameters.impot_revenu.bareme.get_at_instant(instant))
-
-    return parameters, dir, instant, reform_period, verbose
+T = TypeVar("T", bound="ParametricReform")
 
 
-def decote(args: tuple) -> tuple:
-    parameters, dir, instant, reform_period, verbose = args
-    dird = dir["decote"]
-    seuil_celib = dird["seuil_celib"]
-    seuil_couple = dird["seuil_couple"]
-    taux = dird["taux"]
-    if verbose:
-        print("decote avant modif : ")
-        print(
-            parameters.impot_revenu.decote.seuil_celib.get_at_instant(instant),
-            parameters.impot_revenu.decote.seuil_couple.get_at_instant(instant),
-            parameters.impot_revenu.decote.taux.get_at_instant(instant),
-        )
-    parameters.impot_revenu.decote.seuil_celib.update(
-        period=reform_period, value=float(seuil_celib)
-    )
-    parameters.impot_revenu.decote.seuil_couple.update(
-        period=reform_period, value=float(seuil_couple)
-    )
-    parameters.impot_revenu.decote.taux.update(period=reform_period, value=float(taux))
-    if verbose:
-        print("decote apres modif : ")
-        print(
-            parameters.impot_revenu.decote.seuil_celib.get_at_instant(instant),
-            parameters.impot_revenu.decote.seuil_couple.get_at_instant(instant),
-            parameters.impot_revenu.decote.taux.get_at_instant(instant),
-        )
+class ParametricReform(NamedTuple):
+    """Une réforme fiscale"""
 
-    return parameters, dir, instant, reform_period, verbose
+    parameters: ParameterNode
+    payload: dict
+    instant: periods.Instant
+    period: periods.Period
+
+    def __call__(self: T, function: Callable[[T], T]) -> T:
+        return function(self)
 
 
-def plafond_qf(args: tuple) -> tuple:
-    parameters, dir, instant, reform_period, verbose = args
+def reforms(payload: dict) -> tuple:
+    mapping = {
+        "decote": decote,
+        "bareme": bareme,
+        "abattements_rni": abattements_rni,
+        "plafond_qf": compose(plafond_qf, abat_dom, reduction_ss_condition_revenus),
+    }
 
-    if verbose:
-        print("plaf qf avant :")
-        print(parameters.impot_revenu.plafond_qf.get_at_instant(instant))
-    dirr = dir["plafond_qf"]
+    return tuple(mapping[reform] for reform in tuple(payload) if reform in mapping)
 
-    # if "maries_ou_pacses" in requete["impot_revenu"]["plafond_qf"]:
-    #     parameters.impot_revenu.plafond_qf.maries_ou_pacses.update(
-    #         period=reform_period,
-    #         value=requete["impot_revenu"]["plafond_qf"]["maries_ou_pacses"],
-    #     )
 
-    for var_name in [
+def update(items, keys, node, period):
+    for (key, value) in items:
+        if key in keys:
+            parameter = getattr(node, key)
+            parameter.update(period=period, value=float(value))
+
+
+def bareme(reform: T) -> T:
+    seuils = reform.payload.get("bareme", {}).get("seuils")
+    taux = reform.payload.get("bareme", {}).get("taux")
+    node = reform.parameters.impot_revenu.bareme.brackets
+
+    if seuils:
+        for i in range(len(seuils)):
+            node[i].threshold.update(period=reform.period, value=seuils[i])
+
+        for i in range(len(seuils), len(node) - 1):
+            node[i].threshold.update(period=reform.period, value=seuils[-1] + i)
+
+    if taux:
+        for i in range(len(taux)):
+            node[i].rate.update(period=reform.period, value=taux[i] * 0.01)
+
+        for i in range(len(taux), len(node) - 1):
+            node[i].rate.update(period=reform.period, value=taux[-1] * 0.01)
+
+    return type(reform)(*reform)
+
+
+def decote(reform: T) -> T:
+    seuil_couple = reform.payload.get("decote", {}).get("seuil_couple")
+    seuil_celib = reform.payload.get("decote", {}).get("seuil_celib")
+    taux = reform.payload.get("decote", {}).get("taux")
+    node = reform.parameters.impot_revenu.decote
+
+    if seuil_couple:
+        node.seuil_couple.update(period=reform.period, value=float(seuil_couple))
+
+    if seuil_celib:
+        node.seuil_celib.update(period=reform.period, value=float(seuil_celib))
+
+    if taux:
+        node.seuil_celib.update(period=reform.period, value=float(taux))
+
+    return type(reform)(*reform)
+
+
+def abattements_rni(reform: T) -> T:
+    abattements_rni = reform.payload.get("abattements_rni", {})
+    payload = abattements_rni.get("personne_agee_ou_invalide", {})
+    node = reform.parameters.impot_revenu.abattements_rni.personne_agee_ou_invalide
+    keys = ["montant_1", "montant_2", "plafond_1", "plafond_2"]
+    update(payload.items(), keys, node, reform.period)
+    return type(reform)(*reform)
+
+
+def plafond_qf(reform: T) -> T:
+    payload = reform.payload.get("plafond_qf", {})
+    node = reform.parameters.impot_revenu.plafond_qf
+    keys = [
         "maries_ou_pacses",
         "celib_enf",
         "celib",
         "reduc_postplafond",
         "reduc_postplafond_veuf",
-    ]:
-        if var_name in dirr:
-            pp = eval("parameters.impot_revenu.plafond_qf.{}".format(var_name))
-            pp.update(period=reform_period, value=float(dirr[var_name]))
-
-    if "abat_dom" in dirr:
-        paramstoprint = [
-            parameters.impot_revenu.plafond_qf.abat_dom.taux_GuadMarReu,
-            parameters.impot_revenu.plafond_qf.abat_dom.plaf_GuadMarReu,
-            parameters.impot_revenu.plafond_qf.abat_dom.taux_GuyMay,
-            parameters.impot_revenu.plafond_qf.abat_dom.plaf_GuyMay,
-        ]
-        if verbose:
-            print("abat_dom avant modif : ")
-            for pp in paramstoprint:
-                print(pp.get_at_instant(instant))
-        dirrr = dirr["abat_dom"]
-        taux_GuadMarReu = dirrr["taux_GuadMarReu"]
-        parameters.impot_revenu.plafond_qf.abat_dom.taux_GuadMarReu.update(
-            period=reform_period, value=float(taux_GuadMarReu)
-        )
-        plaf_GuadMarReu = dirrr["plaf_GuadMarReu"]
-        parameters.impot_revenu.plafond_qf.abat_dom.plaf_GuadMarReu.update(
-            period=reform_period, value=float(plaf_GuadMarReu)
-        )
-        taux_GuyMay = dirrr["taux_GuyMay"]
-        parameters.impot_revenu.plafond_qf.abat_dom.taux_GuyMay.update(
-            period=reform_period, value=float(taux_GuyMay)
-        )
-        plaf_GuyMay = dirrr["plaf_GuyMay"]
-        parameters.impot_revenu.plafond_qf.abat_dom.plaf_GuyMay.update(
-            period=reform_period, value=float(plaf_GuyMay)
-        )
-    if "reduction_ss_condition_revenus" in dirr:
-        dirrr = dirr["reduction_ss_condition_revenus"]
-        for var_name in ["seuil_maj_enf", "seuil1", "seuil2", "taux"]:
-            if var_name in dirrr:
-                pp = eval(
-                    "parameters.impot_revenu.plafond_qf.reduction_ss_condition_revenus.{}".format(
-                        var_name
-                    )
-                )
-                pp.update(period=reform_period, value=float(dirrr[var_name]))
-
-    if verbose:
-        print("plaf qf après :")
-        print(parameters.impot_revenu.plafond_qf.get_at_instant(instant))
-
-    return parameters, dir, instant, reform_period, verbose
+    ]
+    update(payload.items(), keys, node, reform.period)
+    return type(reform)(*reform)
 
 
-def abattements_rni(args: tuple) -> tuple:
-    parameters, dir, instant, reform_period, verbose = args
-    if verbose:
-        print("abattements_rni :")
-        print(parameters.impot_revenu.abattements_rni.get_at_instant(instant))
-    try:
-        dirr = dir["abattements_rni"]["personne_agee_ou_invalide"]
-    except KeyError:
-        dirr = {}
-    print(dirr)
-    print("au cas ou", dir)
-    # if "maries_ou_pacses" in requete["impot_revenu"]["plafond_qf"]:
-    #     parameters.impot_revenu.plafond_qf.maries_ou_pacses.update(
-    #         period=reform_period,
-    #         value=requete["impot_revenu"]["plafond_qf"]["maries_ou_pacses"],
-    #     )
-
-    for var_name in ["montant_1", "montant_2", "plafond_1", "plafond_2"]:
-        if var_name in dirr:
-            pp = eval(
-                "parameters.impot_revenu.abattements_rni.personne_agee_ou_invalide.{}".format(
-                    var_name
-                )
-            )
-            pp.update(period=reform_period, value=float(dirr[var_name]))
-
-    if verbose:
-        print("abattements_rni après :")
-        print(parameters.impot_revenu.abattements_rni.get_at_instant(instant))
-
-    return parameters, dir, instant, reform_period, verbose
+def abat_dom(reform: T) -> T:
+    plafond_qf = reform.payload.get("plafond_qf", {})
+    payload = plafond_qf.get("abat_dom", {})
+    node = reform.parameters.impot_revenu.plafond_qf.abat_dom
+    keys = ["taux_GuadMarReu", "plaf_GuadMarReu", "taux_GuyMay", "plaf_GuyMay"]
+    update(payload.items(), keys, node, reform.period)
+    return type(reform)(*reform)
 
 
-def mapping() -> dict:
-    return {
-        "decote": decote,
-        "bareme": bareme,
-        "plafond_qf": plafond_qf,
-        "abattements_rni": abattements_rni,
-    }
+def reduction_ss_condition_revenus(reform: T) -> T:
+    plafond_qf = reform.payload.get("plafond_qf", {})
+    payload = plafond_qf.get("reduction_ss_condition_revenus", {})
+    node = reform.parameters.impot_revenu.plafond_qf.reduction_ss_condition_revenus
+    keys = ["seuil_maj_enf", "seuil1", "seuil2", "taux"]
+    update(payload.items(), keys, node, reform.period)
+    return type(reform)(*reform)

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -1,17 +1,17 @@
 from functools import partial
-from toolz.functoolz import pipe  # type: ignore
 from typing import Dict, List
-
-import pandas  # type: ignore
 import time
 import os
+
+import pandas  # type: ignore
+from toolz.functoolz import compose  # type: ignore
 
 from openfisca_core.simulation_builder import SimulationBuilder  # type: ignore
 from openfisca_france import FranceTaxBenefitSystem  # type: ignore
 from openfisca_core import periods  # type: ignore
 from openfisca_france.model.base import Reform  # type: ignore
 
-from Simulation_engine.reforms import mapping
+from Simulation_engine.reforms import ParametricReform, reforms
 
 # Config
 version_beta_sans_simu_pop = True
@@ -48,8 +48,8 @@ def reform_generique(tbs, dictparams, period):
 
         if "impot_revenu" in dictparams:
             dir = dictparams["impot_revenu"]
-            args = (parameters, dir, instant, reform_period, verbose)
-            parameters, *_ = pipe(args, *(mapping()[param] for param in tuple(dir)))
+            args = (parameters, dir, instant, reform_period)
+            parameters, *_ = compose(*reforms(dir))(ParametricReform(*args))
 
         return parameters
 

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -39,10 +39,11 @@ def reform_generique(tbs, dictparams, period):
     def reform(parameters, verbose=False):
         if verbose:
             print("Oui je suis censé passer par là")
+
         instant = periods.instant(period)
-        reform_period = periods.period(
-            "year:1900:200"
-        )  # Pour le moment mes réformes sont sur l'éternité
+        # Pour le moment mes réformes sont sur l'éternité
+        reform_period = periods.period("year:1900:200")
+
         if verbose:
             print(dictparams)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [tool:pytest]
-addopts                    = --showlocals --doctest-modules --disable-pytest-warnings
-testpaths                  = tests
-python_files               = test_*.py
-mock_use_standalone_module = true
+addopts                     = --showlocals --doctest-modules --disable-pytest-warnings
+testpaths                   = tests
+python_files                = test_*.py
+mock_use_standalone_module  = true
 
 [flake8]
 max-line-length             = 88

--- a/tests/Simulation_engine/test_reforms.py
+++ b/tests/Simulation_engine/test_reforms.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+from functools import lru_cache
+
+import pytest
+
+from openfisca_core import periods  # type: ignore
+from openfisca_france import FranceTaxBenefitSystem  # type: ignore
+
+from Simulation_engine.reforms import (  # type: ignore
+    ParametricReform,
+    bareme,
+    decote,
+    plafond_qf,
+    abat_dom,
+    reduction_ss_condition_revenus,
+)
+
+TBS = lru_cache()(FranceTaxBenefitSystem)
+
+
+@pytest.fixture
+def parameters():
+    return TBS().parameters
+
+
+@pytest.fixture
+def instant():
+    return periods.instant("2018")
+
+
+@pytest.fixture
+def period():
+    return periods.period("year:1900:200")
+
+
+def test_bareme_taux(parameters, instant, period, mocker):
+    taux = 10
+    payload = {"bareme": {"taux": [taux]}}
+    parameter = parameters.impot_revenu.bareme.brackets[0].rate
+
+    with mocker.patch.object(parameter, "update"):
+        reform = ParametricReform(parameters, payload, instant, period)
+        reform(bareme)
+        parameter.update.assert_called_once_with(period=period, value=taux * 0.01)
+
+
+def test_bareme_seuil(parameters, instant, period, mocker):
+    seuil = 10000
+    payload = {"bareme": {"seuils": [seuil]}}
+    parameter = parameters.impot_revenu.bareme.brackets[0].threshold
+
+    with mocker.patch.object(parameter, "update"):
+        reform = ParametricReform(parameters, payload, instant, period)
+        reform(bareme)
+        parameter.update.assert_called_once_with(period=period, value=seuil)
+
+
+def test_decote_seuil_couple(parameters, instant, period, mocker):
+    seuil_couple = 10000
+    payload = {"decote": {"seuil_couple": seuil_couple}}
+    parameter = parameters.impot_revenu.decote.seuil_couple
+
+    with mocker.patch.object(parameter, "update"):
+        reform = ParametricReform(parameters, payload, instant, period)
+        reform(decote)
+        parameter.update.assert_called_once_with(period=period, value=seuil_couple)
+
+
+def test_decote_seuil_celib(parameters, instant, period, mocker):
+    seuil_celib = 10000
+    payload = {"decote": {"seuil_celib": seuil_celib}}
+    parameter = parameters.impot_revenu.decote.seuil_celib
+
+    with mocker.patch.object(parameter, "update"):
+        reform = ParametricReform(parameters, payload, instant, period)
+        reform(decote)
+        parameter.update.assert_called_once_with(period=period, value=seuil_celib)
+
+
+def test_plafond_qf(parameters, instant, period, mocker):
+    maries_ou_pacses = 10000
+    payload = {"plafond_qf": {"maries_ou_pacses": maries_ou_pacses}}
+    parameter = parameters.impot_revenu.plafond_qf.maries_ou_pacses
+
+    with mocker.patch.object(parameter, "update"):
+        reform = ParametricReform(parameters, payload, instant, period)
+        reform(plafond_qf)
+        parameter.update.assert_called_once_with(period=period, value=maries_ou_pacses)
+
+
+def test_abat_dom(parameters, instant, period, mocker):
+    taux_GuadMarReu = 10000
+    payload = {"plafond_qf": {"abat_dom": {"taux_GuadMarReu": taux_GuadMarReu}}}
+    parameter = parameters.impot_revenu.plafond_qf.abat_dom.taux_GuadMarReu
+
+    with mocker.patch.object(parameter, "update"):
+        reform = ParametricReform(parameters, payload, instant, period)
+        reform(abat_dom)
+        parameter.update.assert_called_once_with(period=period, value=taux_GuadMarReu)
+
+
+def test_reduction_ss_condition_revenus(parameters, instant, period, mocker):
+    taux = 10000
+    payload = {"plafond_qf": {"reduction_ss_condition_revenus": {"taux": taux}}}
+    parameter = parameters.impot_revenu.plafond_qf.reduction_ss_condition_revenus.taux
+
+    with mocker.patch.object(parameter, "update"):
+        reform = ParametricReform(parameters, payload, instant, period)
+        reform(reduction_ss_condition_revenus)
+        parameter.update.assert_called_once_with(period=period, value=taux)

--- a/tests/Simulation_engine/test_reforms.py
+++ b/tests/Simulation_engine/test_reforms.py
@@ -11,6 +11,7 @@ from Simulation_engine.reforms import (  # type: ignore
     ParametricReform,
     bareme,
     decote,
+    abattements_rni,
     plafond_qf,
     abat_dom,
     reduction_ss_condition_revenus,
@@ -37,75 +38,88 @@ def period():
 def test_bareme_taux(parameters, instant, period, mocker):
     taux = 10
     payload = {"bareme": {"taux": [taux]}}
-    parameter = parameters.impot_revenu.bareme.brackets[0].rate
+    node = parameters.impot_revenu.bareme.brackets[0].rate
 
-    with mocker.patch.object(parameter, "update"):
+    with mocker.patch.object(node, "update"):
         reform = ParametricReform(parameters, payload, instant, period)
         reform(bareme)
-        parameter.update.assert_called_once_with(period=period, value=taux * 0.01)
+        node.update.assert_called_once_with(period=period, value=taux * 0.01)
 
 
 def test_bareme_seuil(parameters, instant, period, mocker):
     seuil = 10000
     payload = {"bareme": {"seuils": [seuil]}}
-    parameter = parameters.impot_revenu.bareme.brackets[0].threshold
+    node = parameters.impot_revenu.bareme.brackets[0].threshold
 
-    with mocker.patch.object(parameter, "update"):
+    with mocker.patch.object(node, "update"):
         reform = ParametricReform(parameters, payload, instant, period)
         reform(bareme)
-        parameter.update.assert_called_once_with(period=period, value=seuil)
+        node.update.assert_called_once_with(period=period, value=seuil)
 
 
 def test_decote_seuil_couple(parameters, instant, period, mocker):
     seuil_couple = 10000
     payload = {"decote": {"seuil_couple": seuil_couple}}
-    parameter = parameters.impot_revenu.decote.seuil_couple
+    node = parameters.impot_revenu.decote.seuil_couple
 
-    with mocker.patch.object(parameter, "update"):
+    with mocker.patch.object(node, "update"):
         reform = ParametricReform(parameters, payload, instant, period)
         reform(decote)
-        parameter.update.assert_called_once_with(period=period, value=seuil_couple)
+        node.update.assert_called_once_with(period=period, value=seuil_couple)
 
 
 def test_decote_seuil_celib(parameters, instant, period, mocker):
     seuil_celib = 10000
     payload = {"decote": {"seuil_celib": seuil_celib}}
-    parameter = parameters.impot_revenu.decote.seuil_celib
+    node = parameters.impot_revenu.decote.seuil_celib
 
-    with mocker.patch.object(parameter, "update"):
+    with mocker.patch.object(node, "update"):
         reform = ParametricReform(parameters, payload, instant, period)
         reform(decote)
-        parameter.update.assert_called_once_with(period=period, value=seuil_celib)
+        node.update.assert_called_once_with(period=period, value=seuil_celib)
+
+
+def test_abattement_rni(parameters, instant, period, mocker):
+    montant_1 = 10000
+    payload = {
+        "abattements_rni": {"personne_agee_ou_invalide": {"montant_1": montant_1}}
+    }
+    node = parameters.impot_revenu.abattements_rni.personne_agee_ou_invalide.montant_1
+
+    with mocker.patch.object(node, "update"):
+        reform = ParametricReform(parameters, payload, instant, period)
+        reform(abattements_rni)
+        node.update.assert_called_once_with(period=period, value=montant_1)
 
 
 def test_plafond_qf(parameters, instant, period, mocker):
     maries_ou_pacses = 10000
     payload = {"plafond_qf": {"maries_ou_pacses": maries_ou_pacses}}
-    parameter = parameters.impot_revenu.plafond_qf.maries_ou_pacses
+    node = parameters.impot_revenu.plafond_qf.maries_ou_pacses
 
-    with mocker.patch.object(parameter, "update"):
+    with mocker.patch.object(node, "update"):
         reform = ParametricReform(parameters, payload, instant, period)
         reform(plafond_qf)
-        parameter.update.assert_called_once_with(period=period, value=maries_ou_pacses)
+        node.update.assert_called_once_with(period=period, value=maries_ou_pacses)
 
 
 def test_abat_dom(parameters, instant, period, mocker):
     taux_GuadMarReu = 10000
     payload = {"plafond_qf": {"abat_dom": {"taux_GuadMarReu": taux_GuadMarReu}}}
-    parameter = parameters.impot_revenu.plafond_qf.abat_dom.taux_GuadMarReu
+    node = parameters.impot_revenu.plafond_qf.abat_dom.taux_GuadMarReu
 
-    with mocker.patch.object(parameter, "update"):
+    with mocker.patch.object(node, "update"):
         reform = ParametricReform(parameters, payload, instant, period)
         reform(abat_dom)
-        parameter.update.assert_called_once_with(period=period, value=taux_GuadMarReu)
+        node.update.assert_called_once_with(period=period, value=taux_GuadMarReu)
 
 
 def test_reduction_ss_condition_revenus(parameters, instant, period, mocker):
     taux = 10000
     payload = {"plafond_qf": {"reduction_ss_condition_revenus": {"taux": taux}}}
-    parameter = parameters.impot_revenu.plafond_qf.reduction_ss_condition_revenus.taux
+    node = parameters.impot_revenu.plafond_qf.reduction_ss_condition_revenus.taux
 
-    with mocker.patch.object(parameter, "update"):
+    with mocker.patch.object(node, "update"):
         reform = ParametricReform(parameters, payload, instant, period)
         reform(reduction_ss_condition_revenus)
-        parameter.update.assert_called_once_with(period=period, value=taux)
+        node.update.assert_called_once_with(period=period, value=taux)

--- a/tests/Simulation_engine/test_reforms.py
+++ b/tests/Simulation_engine/test_reforms.py
@@ -2,7 +2,7 @@
 
 from functools import lru_cache
 
-import pytest
+from pytest import fixture  # type: ignore
 
 from openfisca_core import periods  # type: ignore
 from openfisca_france import FranceTaxBenefitSystem  # type: ignore
@@ -19,17 +19,17 @@ from Simulation_engine.reforms import (  # type: ignore
 TBS = lru_cache()(FranceTaxBenefitSystem)
 
 
-@pytest.fixture
+@fixture
 def parameters():
     return TBS().parameters
 
 
-@pytest.fixture
+@fixture
 def instant():
     return periods.instant("2018")
 
 
-@pytest.fixture
+@fixture
 def period():
     return periods.period("year:1900:200")
 


### PR DESCRIPTION
- Separate reforms as pseudo-pure functions
- Use a named tuple to carry data around
- Better use of function composition
- Tests

(ParameterNode is an obscure data type, eager loaded, non-enumerable and essentially mutable, so there’s no easy way to render reforms pure functions. Which is ok given openfisca clones itself the tax benefit system when applying a reform.)