### PR TITLE
Correction d'un bug qui multipliait par 0.01 les valeurs qui étaient déjà multipliées par 0.01 au niveau du server

### DIFF
--- a/Simulation_engine/reforms.py
+++ b/Simulation_engine/reforms.py
@@ -52,9 +52,7 @@ def decote(args: tuple) -> tuple:
     parameters.impot_revenu.decote.seuil_couple.update(
         period=reform_period, value=float(seuil_couple)
     )
-    parameters.impot_revenu.decote.taux.update(
-        period=reform_period, value=float(taux) * 0.01
-    )
+    parameters.impot_revenu.decote.taux.update(period=reform_period, value=float(taux))
     if verbose:
         print("decote apres modif : ")
         print(

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -139,7 +139,7 @@ components:
                     seuil_couple:
                       type: integer
                     taux:
-                      type: integer
+                      type: number
                 plafond_qf:
                   type: object
                   properties:


### PR DESCRIPTION
Par souci de cohérence,  tous les paramètres (à l'exception des impot_revenu.bareme.taux qui sont de la legacy mais bon même lui on devrait le changer) sont entrés dans l'API exactement de la manière dont ils sont rentrés dans openfisca.