### PR TITLE
[WIP] Taux barême en pourcentage

### DIFF
--- a/Simulation_engine/reforms.py
+++ b/Simulation_engine/reforms.py
@@ -12,7 +12,7 @@ def bareme(args: tuple) -> tuple:
             period=reform_period, value=seuils[i]
         )
         parameters.impot_revenu.bareme.brackets[i].rate.update(
-            period=reform_period, value=taux[i] * 0.01
+            period=reform_period, value=taux[i]
         )
 
     for i in range(len(seuils), 15):
@@ -21,7 +21,7 @@ def bareme(args: tuple) -> tuple:
                 period=reform_period, value=seuils[-1] + i
             )
             parameters.impot_revenu.bareme.brackets[i].rate.update(
-                period=reform_period, value=taux[-1] * 0.01
+                period=reform_period, value=taux[-1]
             )
         except (Exception):
             break

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -656,7 +656,7 @@ if __name__ == "__main__":
     dictreform = {
         "impot_revenu": {
             "bareme": {
-                "seuils": [0,9964, 27159, 73779, 156244],
+                "seuils": [0, 9964, 27159, 73779, 156244],
                 "taux": [0, 0.14, 0.30, 0.41, 0.45]
             },
             "decote": {"seuil_celib": 1000, "seuil_couple": 2000},

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -653,7 +653,7 @@ def CompareOldNew(taux=None, isdecile=True, dictreform=None, castypedesc=None):
 
 
 if __name__ == "__main__":
-    taux = [9964, 27159, 73779, 156244, 14, 30, 41, 45]
+    taux = [9964, 27159, 73779, 156244, 0.14, 0.30, 0.41, 0.45]
     dictreform = {
         "impot_revenu": {
             "bareme": {

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -653,12 +653,11 @@ def CompareOldNew(taux=None, isdecile=True, dictreform=None, castypedesc=None):
 
 
 if __name__ == "__main__":
-    taux = [9964, 27159, 73779, 156244, 0.14, 0.30, 0.41, 0.45]
     dictreform = {
         "impot_revenu": {
             "bareme": {
-                "seuils": [0] + taux[: len(taux) // 2],
-                "taux": [0] + taux[len(taux) // 2 :],
+                "seuils": [0,9964, 27159, 73779, 156244],
+                "taux": [0, 0.14, 0.30, 0.41, 0.45]
             },
             "decote": {"seuil_celib": 1000, "seuil_couple": 2000},
         }

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -640,7 +640,7 @@ def CompareOldNew(taux=None, isdecile=True, dictreform=None, castypedesc=None):
             "impot_revenu": {
                 "bareme": {
                     "seuils": [0] + taux[: len(taux) // 2],
-                    "taux": [0] + taux[len(taux) // 2 :],
+                    "taux": [0.0] + taux[len(taux) // 2 :],
                 }
             }
         }

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -11,7 +11,7 @@ def payload() -> dict:
             "impot_revenu": {
                 "bareme": {
                     "seuils": [9964, 27519, 73779, 156244],
-                    "taux": [12, 30, 41, 45],
+                    "taux": [0.12, 0.30, 0.41, 0.45],
                 },
                 "decote": {"seuil_celib": 1196, "seuil_couple": 1970, "taux": 50},
                 "plafond_qf": {


### PR DESCRIPTION
Les taux du barême sont désormais entrés de manière homogène à la manière dont ils sont entrés dans openfisca, i.e. on ne divise plus par 100

Pour merger cette PR, il faut :
- merger la correspondante dans le client en même temps (elle s'appelle aussi pourcentage_bareme_taux)
- la rebaser sur le master parce que là je l'ai foutue un peu n'importe où 