### PR TITLE
Correction bug decote

### DIFF
--- a/Simulation_engine/reforms.py
+++ b/Simulation_engine/reforms.py
@@ -83,20 +83,20 @@ def bareme(reform: T) -> T:
 
 
 def decote(reform: T) -> T:
+    print("mon payload : ", reform.payload.get("decote", {}))
     seuil_couple = reform.payload.get("decote", {}).get("seuil_couple")
     seuil_celib = reform.payload.get("decote", {}).get("seuil_celib")
     taux = reform.payload.get("decote", {}).get("taux")
     node = reform.parameters.impot_revenu.decote
 
-    if seuil_couple:
+    if seuil_couple is not None:
         node.seuil_couple.update(period=reform.period, value=float(seuil_couple))
 
-    if seuil_celib:
+    if seuil_celib is not None:
         node.seuil_celib.update(period=reform.period, value=float(seuil_celib))
 
-    if taux:
-        node.seuil_celib.update(period=reform.period, value=float(taux))
-
+    if taux is not None:
+        node.taux.update(period=reform.period, value=float(taux))
     return type(reform)(*reform)
 
 

--- a/Simulation_engine/reforms.py
+++ b/Simulation_engine/reforms.py
@@ -83,7 +83,6 @@ def bareme(reform: T) -> T:
 
 
 def decote(reform: T) -> T:
-    print("mon payload : ", reform.payload.get("decote", {}))
     seuil_couple = reform.payload.get("decote", {}).get("seuil_couple")
     seuil_celib = reform.payload.get("decote", {}).get("seuil_celib")
     taux = reform.payload.get("decote", {}).get("taux")


### PR DESCRIPTION
une typo donnait à une variable la valeur d'une autre + un problème ne prenait pas en compte les variables remises à 0.

