### PR TITLE
Changement du taux en pourcentage par cohérence

### DIFF
--- a/Simulation_engine/reforms.py
+++ b/Simulation_engine/reforms.py
@@ -74,10 +74,10 @@ def bareme(reform: T) -> T:
 
     if taux:
         for i in range(len(taux)):
-            node[i].rate.update(period=reform.period, value=taux[i] * 0.01)
+            node[i].rate.update(period=reform.period, value=taux[i])
 
         for i in range(len(taux), len(node) - 1):
-            node[i].rate.update(period=reform.period, value=taux[-1] * 0.01)
+            node[i].rate.update(period=reform.period, value=taux[-1])
 
     return type(reform)(*reform)
 

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -565,7 +565,7 @@ def CompareOldNew(taux=None, isdecile=True, dictreform=None, castypedesc=None):
             "impot_revenu": {
                 "bareme": {
                     "seuils": [0] + taux[: len(taux) // 2],
-                    "taux": [0] + taux[len(taux) // 2 :],
+                    "taux": [0.0] + taux[len(taux) // 2 :],
                 }
             }
         }
@@ -579,20 +579,16 @@ def CompareOldNew(taux=None, isdecile=True, dictreform=None, castypedesc=None):
 
 
 if __name__ == "__main__":
-    taux = [9964, 27159, 73779, 156244, 14, 30, 41, 45]
     dictreform = {
         "impot_revenu": {
             "bareme": {
-                "seuils": [0] + taux[: len(taux) // 2],
-                "taux": [0] + taux[len(taux) // 2 :],
+                "seuils": [0, 9964, 27159, 73779, 156244],
+                "taux": [0, 0.14, 0.30, 0.41, 0.45]
             },
             "decote": {"seuil_celib": 1000, "seuil_couple": 2000},
         }
     }
     reform = IncomeTaxReform(TBS, dictreform, PERIOD)
-    # reform = reform_from_bareme(
-    #     TBS, [0] + taux[: len(taux) // 2], [0] + taux[len(taux) // 2 :], PERIOD
-    # )
     if version_beta_sans_simu_pop:
         simulation_reform = simulation(PERIOD, CAS_TYPE, reform, timer=time)
         compare(

--- a/tests/Simulation_engine/test_reforms.py
+++ b/tests/Simulation_engine/test_reforms.py
@@ -36,14 +36,14 @@ def period():
 
 
 def test_bareme_taux(parameters, instant, period, mocker):
-    taux = 10
+    taux = 0.1
     payload = {"bareme": {"taux": [taux]}}
     node = parameters.impot_revenu.bareme.brackets[0].rate
 
     with mocker.patch.object(node, "update"):
         reform = ParametricReform(parameters, payload, instant, period)
         reform(bareme)
-        node.update.assert_called_once_with(period=period, value=taux * 0.01)
+        node.update.assert_called_once_with(period=period, value=taux )
 
 
 def test_bareme_seuil(parameters, instant, period, mocker):

--- a/tests/Simulation_engine/test_reforms.py
+++ b/tests/Simulation_engine/test_reforms.py
@@ -43,7 +43,7 @@ def test_bareme_taux(parameters, instant, period, mocker):
     with mocker.patch.object(node, "update"):
         reform = ParametricReform(parameters, payload, instant, period)
         reform(bareme)
-        node.update.assert_called_once_with(period=period, value=taux )
+        node.update.assert_called_once_with(period=period, value=taux)
 
 
 def test_bareme_seuil(parameters, instant, period, mocker):

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -11,7 +11,7 @@ def payload() -> dict:
             "impot_revenu": {
                 "bareme": {
                     "seuils": [9964, 27519, 73779, 156244],
-                    "taux": [12, 30, 41, 45],
+                    "taux": [0.12, 0.30, 0.41, 0.45],
                 },
                 "decote": {"seuil_celib": 1196, "seuil_couple": 1970, "taux": 50},
                 "plafond_qf": {


### PR DESCRIPTION
Les taux du barême sont désormais entrés de manière homogène à la manière dont ils sont entrés dans openfisca, i.e. on ne divise plus par 100 les inputs de l'API call

Pour merger cette PR, il faut  merger la correspondante dans le client en même temps (elle s'appelle pourcentage_bareme_taux)