### PR TITLE
Add timestamp

### DIFF
--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -110,22 +110,6 @@ def simulation(period, data, tbs):
                 period,
                 dictionnaire_datagrouped[tbs.get_variable(colonne).entity.key][colonne],
             )
-            # print(
-            #     "{} was attributed to {}".format(
-            #         colonne, tbs.get_variable(colonne).entity.key
-            #     )
-            # )
-
-            # except (Exception):
-            #     try:
-            #         print(
-            #             "{} failed to be attributed to {}".format(
-            #                 colonne, tbs.get_variable(colonne).entity.key
-            #             )
-            #         )
-            #     except (Exception):
-            #         print("{} was attributed to NOUGHT".format(colonne))
-            #     raise
     return simulation, dictionnaire_datagrouped
 
 
@@ -146,15 +130,6 @@ def compare(period: str, simulation_base, simulation_reform, compute_deciles=Tru
                 * dictionnaire_datagrouped["foyer_fiscal"]["wprm"]
             )
 
-            # print(
-            #     "{} sum : {}  mean : {}".format(
-            #         nomvariable,
-            #         dictionnaire_datagrouped["foyer_fiscal"][nomvariable + "w"].sum(),
-            #         dictionnaire_datagrouped["foyer_fiscal"][nomvariable + "w"].sum()
-            #         / dictionnaire_datagrouped["foyer_fiscal"]["wprm"].sum(),
-            #     )
-            # )
-
             if nomvariable == "irpp":
                 res += [
                     -dictionnaire_datagrouped["foyer_fiscal"][nomvariable + "w"].sum()
@@ -168,7 +143,6 @@ def compare(period: str, simulation_base, simulation_reform, compute_deciles=Tru
     total: Total = {"avant": res[0], "apres": res[1]}
 
     if compute_deciles:
-        # print("Computing Deciles")
         totweight = dictionnaire_datagrouped["foyer_fiscal"]["wprm"].sum()
         nbd = 10
         decilweights = [i / nbd * totweight for i in range(nbd + 1)]
@@ -200,9 +174,6 @@ def compare(period: str, simulation_base, simulation_reform, compute_deciles=Tru
                 ]
                 numdecile += 1
 
-        # print("In fine ", currw, currb, curra)
-        # print("mes valeurs agreg deciles :", decilesres)
-        # print("mes valeurs diff deciles :", decdiffres)
         # TODO : interpolate quantiles instead of doing the granular approach
         # This is the only TODO part in this code, I highly doubt it's the most pressing matter
 
@@ -219,7 +190,6 @@ def compare(period: str, simulation_base, simulation_reform, compute_deciles=Tru
     else:  # This only interests us for the castypes
         resultat = {"total": total, "res_brut": df.to_dict()}
 
-    # print(resultat)
     return resultat
 
 
@@ -275,7 +245,6 @@ def foyertotexte(idfoy, data=None):
     if data is None:
         data = CAS_TYPE
     myct = data[data["idfoy"] == idfoy]
-    # print("Je fais un foyer to texte pour le foyer ",idfoy,myct)
     decl = myct[myct["quifoyof"] == "declarant_principal"]
     nbdecl = len(decl)
     nbpacs = len(myct) - nbdecl
@@ -576,7 +545,6 @@ if __name__ == "__main__":
         compare(
             PERIOD, simulation_base_castypes, simulation_reform, compute_deciles=False
         )
-        print("Et l'autre)")
         CompareOldNew("osef", False, dictreform, desc_cas_types())
     else:
         simulation_reform = simulation(PERIOD, DUMMY_DATA, reform)

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -1,6 +1,5 @@
 from functools import partial
 from typing import Dict, List, Optional
-import time
 import os
 
 import pandas  # type: ignore
@@ -35,11 +34,7 @@ def load_data(filename: Optional[str]):
     return from_postgres(filename)
 
 
-def simulation(period, data, tbs, timer=None):
-    if timer is not None:
-        starttime = timer.time()
-        print("Elapsed time : {:.2f}".format(timer.time() - starttime))
-
+def simulation(period, data, tbs):
     # Traduction des roles attribués au format openfisca
     data["quimenof"] = "enfant"
     data.loc[data["quifoy"] == 1, "quimenof"] = "conjoint"
@@ -109,40 +104,32 @@ def simulation(period, data, tbs, timer=None):
     # Attribution des variables à la bonne entité OpenFisca
     for colonne in data.columns:
         if colonne not in columns_not_OF_variables:
-            try:
-                simulation.set_input(
-                    colonne,
-                    period,
-                    dictionnaire_datagrouped[tbs.get_variable(colonne).entity.key][
-                        colonne
-                    ],
-                )
-                print(
-                    "{} was attributed to {}".format(
-                        colonne, tbs.get_variable(colonne).entity.key
-                    )
-                )
+            # try:
+            simulation.set_input(
+                colonne,
+                period,
+                dictionnaire_datagrouped[tbs.get_variable(colonne).entity.key][colonne],
+            )
+            # print(
+            #     "{} was attributed to {}".format(
+            #         colonne, tbs.get_variable(colonne).entity.key
+            #     )
+            # )
 
-            except (Exception):
-                try:
-                    print(
-                        "{} failed to be attributed to {}".format(
-                            colonne, tbs.get_variable(colonne).entity.key
-                        )
-                    )
-                except (Exception):
-                    print("{} was attributed to NOUGHT".format(colonne))
-                raise
-
-    if timer is not None:
-        print("Elapsed time : {:.2f}".format(timer.time() - starttime))
-
+            # except (Exception):
+            #     try:
+            #         print(
+            #             "{} failed to be attributed to {}".format(
+            #                 colonne, tbs.get_variable(colonne).entity.key
+            #             )
+            #         )
+            #     except (Exception):
+            #         print("{} was attributed to NOUGHT".format(colonne))
+            #     raise
     return simulation, dictionnaire_datagrouped
 
 
-def compare(
-    period: str, simulation_base, simulation_reform, compute_deciles=True, timer=None
-):
+def compare(period: str, simulation_base, simulation_reform, compute_deciles=True):
     res: List[float] = []
     kk = 0
 
@@ -150,8 +137,6 @@ def compare(
         if not kk:
             df = dictionnaire_datagrouped["foyer_fiscal"][["wprm"]]
         for nomvariable in ["irpp", "nbptr"]:
-            if timer is not None:
-                starttime = timer.time()
 
             dictionnaire_datagrouped["foyer_fiscal"][
                 nomvariable
@@ -161,17 +146,14 @@ def compare(
                 * dictionnaire_datagrouped["foyer_fiscal"]["wprm"]
             )
 
-            print(
-                "{} sum : {}  mean : {}".format(
-                    nomvariable,
-                    dictionnaire_datagrouped["foyer_fiscal"][nomvariable + "w"].sum(),
-                    dictionnaire_datagrouped["foyer_fiscal"][nomvariable + "w"].sum()
-                    / dictionnaire_datagrouped["foyer_fiscal"]["wprm"].sum(),
-                )
-            )
-
-            if timer is not None:
-                print("Elapsed time : {:.2f}".format(timer.time() - starttime))
+            # print(
+            #     "{} sum : {}  mean : {}".format(
+            #         nomvariable,
+            #         dictionnaire_datagrouped["foyer_fiscal"][nomvariable + "w"].sum(),
+            #         dictionnaire_datagrouped["foyer_fiscal"][nomvariable + "w"].sum()
+            #         / dictionnaire_datagrouped["foyer_fiscal"]["wprm"].sum(),
+            #     )
+            # )
 
             if nomvariable == "irpp":
                 res += [
@@ -186,7 +168,7 @@ def compare(
     total: Total = {"avant": res[0], "apres": res[1]}
 
     if compute_deciles:
-        print("Computing Deciles")
+        # print("Computing Deciles")
         totweight = dictionnaire_datagrouped["foyer_fiscal"]["wprm"].sum()
         nbd = 10
         decilweights = [i / nbd * totweight for i in range(nbd + 1)]
@@ -201,8 +183,6 @@ def compare(
         dfv = df.values
         decilesres = [[0, 0, 0]]
         decdiffres: Deciles = []
-        print(decilweights, dfv[0], totweight)
-        print(dfv[1])
         eps = 0.0001
         keysdicres = ["poids", "avant", "apres"]
         for v in dfv:
@@ -220,9 +200,9 @@ def compare(
                 ]
                 numdecile += 1
 
-        print("In fine ", currw, currb, curra)
-        print("mes valeurs agreg deciles :", decilesres)
-        print("mes valeurs diff deciles :", decdiffres)
+        # print("In fine ", currw, currb, curra)
+        # print("mes valeurs agreg deciles :", decilesres)
+        # print("mes valeurs diff deciles :", decdiffres)
         # TODO : interpolate quantiles instead of doing the granular approach
         # This is the only TODO part in this code, I highly doubt it's the most pressing matter
 
@@ -239,7 +219,7 @@ def compare(
     else:  # This only interests us for the castypes
         resultat = {"total": total, "res_brut": df.to_dict()}
 
-    print(resultat)
+    # print(resultat)
     return resultat
 
 
@@ -281,10 +261,10 @@ if not version_beta_sans_simu_pop:
     SIMPOP = partial(simulation, period=PERIOD, data=DUMMY_DATA)
     SIMPOP_BASE = SIMPOP(tbs=TBS)
     # Keeping computations short with option to keep file under 1000 FF
-    DUMMY_DATA = DUMMY_DATA[(DUMMY_DATA["idmen"] > 2500) & (DUMMY_DATA["idmen"] < 7500)]
+    # DUMMY_DATA = DUMMY_DATA[(DUMMY_DATA["idmen"] > 2500) & (DUMMY_DATA["idmen"] < 7500)]
     print("Dummy Data loaded", len(DUMMY_DATA), "lines")
-    simulation_base_deciles = simulation(PERIOD, DUMMY_DATA, TBS, timer=time)
-simulation_base_castypes = simulation(PERIOD, CAS_TYPE, TBS, timer=time)
+    simulation_base_deciles = simulation(PERIOD, DUMMY_DATA, TBS)
+simulation_base_castypes = simulation(PERIOD, CAS_TYPE, TBS)
 
 
 def foyertosomethingelse(idfoy):
@@ -333,7 +313,6 @@ def foyertorevenu(idfoy, data=None):
         data[data["idfoy"] == idfoy]["salaire_de_base"].sum()
         + data[data["idfoy"] == idfoy]["retraite_brute"].sum()
     )
-    print(idfoy, "est mon idfoy et mon rev ", revenu)
     return revenu
 
 
@@ -374,7 +353,6 @@ def foyertodictcastype(idfoy, data=None):
         "nombre_declarants_retraites": int(nbret),
         "outre_mer": 1 * outremer1 + 2 * outremer2,
     }
-    print(dicres)
     return dicres
 
 
@@ -384,7 +362,6 @@ def revenus_cas_types(data=None):
     dic_res = {}
     for k in data["idfoy"].values:
         dic_res[k] = foyertorevenu(k, data)
-    print("dic_res ", dic_res)
     return dic_res
 
 
@@ -406,7 +383,7 @@ def texte_cas_types(data=None):
 
 def simulation_from_ct(descriptions):
     df = dataframe_from_ct_desc(descriptions)
-    return (df, simulation(PERIOD, df, TBS, timer=time))
+    return (df, simulation(PERIOD, df, TBS))
 
 
 # Transforme une description de cas types en un dataframe parsable. Good luck!
@@ -492,7 +469,6 @@ def dataframe_from_ct_desc(descriptions):
     indexfoyer = 0
     indexpac = 2
     for ct in descriptions:
-        print("myct : ", ct)
         nbd = ct["nombre_declarants"]
         nbc = ct["nombre_personnes_a_charge"]
         for colid in ["idfoy", "idmen", "idfam"]:
@@ -554,7 +530,6 @@ def dataframe_from_ct_desc(descriptions):
 
 
 def CompareOldNew(taux=None, isdecile=True, dictreform=None, castypedesc=None):
-    print("comparing old new, isdecile = {} ".format(isdecile))
     # if isdecile, we want the impact on the full population, while just a cas type on
     # the isdecile=False
     data, simulation_base = (
@@ -581,8 +556,8 @@ def CompareOldNew(taux=None, isdecile=True, dictreform=None, castypedesc=None):
     #   reform = reform_from_bareme(
     #       TBS, [0] + taux[: len(taux) // 2], [0] + taux[len(taux) // 2 :], PERIOD
     #   )
-    simulation_reform = simulation(PERIOD, data, reform, timer=time)
-    return compare(PERIOD, simulation_base, simulation_reform, isdecile, timer=time)
+    simulation_reform = simulation(PERIOD, data, reform)
+    return compare(PERIOD, simulation_base, simulation_reform, isdecile)
 
 
 if __name__ == "__main__":
@@ -597,17 +572,13 @@ if __name__ == "__main__":
     }
     reform = IncomeTaxReform(TBS, dictreform, PERIOD)
     if version_beta_sans_simu_pop:
-        simulation_reform = simulation(PERIOD, CAS_TYPE, reform, timer=time)
+        simulation_reform = simulation(PERIOD, CAS_TYPE, reform)
         compare(
-            PERIOD,
-            simulation_base_castypes,
-            simulation_reform,
-            compute_deciles=False,
-            timer=time,
+            PERIOD, simulation_base_castypes, simulation_reform, compute_deciles=False
         )
         print("Et l'autre)")
         CompareOldNew("osef", False, dictreform, desc_cas_types())
     else:
-        simulation_reform = simulation(PERIOD, DUMMY_DATA, reform, timer=time)
-        compare(PERIOD, simulation_base_deciles, simulation_reform, timer=time)
-        compare(PERIOD, None, simulation_reform, timer=time)
+        simulation_reform = simulation(PERIOD, DUMMY_DATA, reform)
+        compare(PERIOD, simulation_base_deciles, simulation_reform)
+        compare(PERIOD, None, simulation_reform)

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -38,19 +38,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/description_cas_types'
-  /calculate/compare_old:
-    post:
-      summary: Calcule l'impact d'une loi
-      operationId: server.handlers.SimulationRunner.compare
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/compareoldnew_old'
-      responses:
-          '201':
-            description: Qu'est ce que c'est description
   /calculate/compare:
     post:
       summary: Calcule l'impact d'une loi

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -95,6 +95,8 @@ components:
           type: string
         deciles:
           type: boolean
+        timestamp:
+          type: string
         reforme:
           type: object
           properties:

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -88,22 +88,6 @@ components:
           type: string
     revenus:
       type: object
-    compareoldnew_old:
-      type: object
-      properties:
-        isdecile:
-          type: boolean
-        bareme_ir:
-          type: object
-          properties:
-            seuils:
-              type: array
-              items:
-                type: integer
-            taux:
-              type: array
-              items:
-                type: number
     compareoldnew:
       type: object
       properties:

--- a/server/handlers/auth.py
+++ b/server/handlers/auth.py
@@ -15,10 +15,10 @@ except FileNotFoundError:
 def login(session, **params: Dict[str, str]) -> Tuple[str, int]:
     jwt = login_user(session, params["body"]["email"])
     if jwt is not None:
-        print(jwt.encoded)
         mail_content = mail_content_initial.replace(
             "$INSERT_LINK_HERE",
             "https://leximpact.beta.gouv.fr/connection/{}".format(jwt.encoded),
+
         )
         send_mail(
             recipient=params["body"]["email"],

--- a/server/handlers/cas_types.py
+++ b/server/handlers/cas_types.py
@@ -21,18 +21,6 @@ class CasTypes(object):
 
 
 class SimulationRunner(object):
-    def compare(**params: dict) -> tuple:
-        dbod = params["body"]
-        return (
-            [
-                CompareOldNew(
-                    dbod["bareme_ir"]["seuils"] + dbod["bareme_ir"]["taux"],
-                    dbod["deciles"],
-                )
-            ],
-            201,
-        )
-
     def simulereforme(**params: dict) -> tuple:
         dbod = params["body"]
         dct = None

--- a/server/handlers/cas_types.py
+++ b/server/handlers/cas_types.py
@@ -4,7 +4,6 @@ from Simulation_engine.simulate_pop_from_reform import (
     revenus_cas_types,
 )
 from server.services import check_user, with_session
-from datetime import datetime
 
 
 def error_as_dict(errormessage):
@@ -23,7 +22,6 @@ class CasTypes(object):
 
 class SimulationRunner(object):
     def simulereforme(**params: dict) -> tuple:
-        timestamprequest = datetime.now()
         dbod = params["body"]
         dct = None
         if "description_cas_types" in dbod:
@@ -33,12 +31,12 @@ class SimulationRunner(object):
         dic_resultat = CompareOldNew(
             taux=None, isdecile=False, dictreform=dbod["reforme"], castypedesc=dct
         )
-        dic_resultat["timestamp"] = timestamprequest
+        if "timestamp" in dbod:
+            dic_resultat["timestamp"] = dbod["timestamp"]
         return (dic_resultat, 201)
 
     @with_session
     def simuledeciles(session, **params: dict) -> tuple:
-        timestamprequest = datetime.now()
         dbod = params["body"]
         if "reforme" not in dbod:
             return error_as_dict("missing 'reforme' field in body of your request"), 200
@@ -56,5 +54,6 @@ class SimulationRunner(object):
         dic_resultat = CompareOldNew(
             taux=None, isdecile=True, dictreform=dbod["reforme"], castypedesc=None
         )
-        dic_resultat["timestamp"] = timestamprequest
+        if "timestamp" in dbod:
+            dic_resultat["timestamp"] = dbod["timestamp"]
         return (dic_resultat, 200)

--- a/server/handlers/cas_types.py
+++ b/server/handlers/cas_types.py
@@ -4,6 +4,7 @@ from Simulation_engine.simulate_pop_from_reform import (
     revenus_cas_types,
 )
 from server.services import check_user, with_session
+from datetime import datetime
 
 
 def error_as_dict(errormessage):
@@ -22,6 +23,7 @@ class CasTypes(object):
 
 class SimulationRunner(object):
     def simulereforme(**params: dict) -> tuple:
+        timestamprequest = datetime.now()
         dbod = params["body"]
         dct = None
         if "description_cas_types" in dbod:
@@ -29,18 +31,15 @@ class SimulationRunner(object):
             dct = dbod["description_cas_types"]
         else:
             isdecile = dbod["deciles"]
-        return (
-            CompareOldNew(
-                taux=None,
-                isdecile=isdecile,
-                dictreform=dbod["reforme"],
-                castypedesc=dct,
-            ),
-            201,
+        dic_resultat = CompareOldNew(
+            taux=None, isdecile=isdecile, dictreform=dbod["reforme"], castypedesc=dct
         )
+        dic_resultat["timestamp"] = timestamprequest
+        return (dic_resultat, 201)
 
     @with_session
     def simuledeciles(session, **params: dict) -> tuple:
+        timestamprequest = datetime.now()
         dbod = params["body"]
         if "token" not in dbod:
             return error_as_dict("missing token : necessary for this request"), 200
@@ -53,9 +52,8 @@ class SimulationRunner(object):
                 200,
             )
 
-        return (
-            CompareOldNew(
-                taux=None, isdecile=True, dictreform=dbod["reforme"], castypedesc=None
-            ),
-            200,
+        dic_resultat = CompareOldNew(
+            taux=None, isdecile=True, dictreform=dbod["reforme"], castypedesc=None
         )
+        dic_resultat["timestamp"] = timestamprequest
+        return (dic_resultat, 200)

--- a/server/handlers/cas_types.py
+++ b/server/handlers/cas_types.py
@@ -27,12 +27,9 @@ class SimulationRunner(object):
         dbod = params["body"]
         dct = None
         if "description_cas_types" in dbod:
-            isdecile = False
             dct = dbod["description_cas_types"]
-        else:
-            isdecile = dbod["deciles"]
         dic_resultat = CompareOldNew(
-            taux=None, isdecile=isdecile, dictreform=dbod["reforme"], castypedesc=dct
+            taux=None, isdecile=False, dictreform=dbod["reforme"], castypedesc=dct
         )
         dic_resultat["timestamp"] = timestamprequest
         return (dic_resultat, 201)

--- a/server/handlers/cas_types.py
+++ b/server/handlers/cas_types.py
@@ -29,7 +29,7 @@ class SimulationRunner(object):
         if "description_cas_types" in dbod:
             dct = dbod["description_cas_types"]
         if "reforme" not in dbod:
-            return error_as_dict("missing 'reforme' field in body of your request"),200
+            return error_as_dict("missing 'reforme' field in body of your request"), 200
         dic_resultat = CompareOldNew(
             taux=None, isdecile=False, dictreform=dbod["reforme"], castypedesc=dct
         )
@@ -41,7 +41,7 @@ class SimulationRunner(object):
         timestamprequest = datetime.now()
         dbod = params["body"]
         if "reforme" not in dbod:
-            return error_as_dict("missing 'reforme' field in body of your request"),200
+            return error_as_dict("missing 'reforme' field in body of your request"), 200
         if "token" not in dbod:
             return error_as_dict("missing token : necessary for this request"), 200
         CU = check_user(session, dbod["token"])

--- a/server/handlers/cas_types.py
+++ b/server/handlers/cas_types.py
@@ -28,6 +28,8 @@ class SimulationRunner(object):
         dct = None
         if "description_cas_types" in dbod:
             dct = dbod["description_cas_types"]
+        if "reforme" not in dbod:
+            return error_as_dict("missing 'reforme' field in body of your request"),200
         dic_resultat = CompareOldNew(
             taux=None, isdecile=False, dictreform=dbod["reforme"], castypedesc=dct
         )
@@ -38,6 +40,8 @@ class SimulationRunner(object):
     def simuledeciles(session, **params: dict) -> tuple:
         timestamprequest = datetime.now()
         dbod = params["body"]
+        if "reforme" not in dbod:
+            return error_as_dict("missing 'reforme' field in body of your request"),200
         if "token" not in dbod:
             return error_as_dict("missing token : necessary for this request"), 200
         CU = check_user(session, dbod["token"])

--- a/server/services/mail_services.py
+++ b/server/services/mail_services.py
@@ -30,6 +30,6 @@ def send_mail(
         ]
     }
     result = mailjet.send.create(data=data)
-    assert result.status_code == 200
-    # print(result.status_code)
+    if result.status_code != 200:
+        print("Error in sending email : ",result.json())    # print(result.status_code)
     # print(result.json())

--- a/server/services/mail_services.py
+++ b/server/services/mail_services.py
@@ -32,4 +32,3 @@ def send_mail(
     result = mailjet.send.create(data=data)
     if result.status_code != 200:
         print("Error in sending email : ", result.json())
-        

--- a/server/services/mail_services.py
+++ b/server/services/mail_services.py
@@ -31,5 +31,5 @@ def send_mail(
     }
     result = mailjet.send.create(data=data)
     if result.status_code != 200:
-        print("Error in sending email : ", result.json())  # print(result.status_code)
-    # print(result.json())
+        print("Error in sending email : ", result.json())
+        

--- a/server/services/mail_services.py
+++ b/server/services/mail_services.py
@@ -30,5 +30,6 @@ def send_mail(
         ]
     }
     result = mailjet.send.create(data=data)
-    print(result.status_code)
-    print(result.json())
+    assert result.status_code == 200
+    # print(result.status_code)
+    # print(result.json())

--- a/server/services/mail_services.py
+++ b/server/services/mail_services.py
@@ -31,5 +31,5 @@ def send_mail(
     }
     result = mailjet.send.create(data=data)
     if result.status_code != 200:
-        print("Error in sending email : ",result.json())    # print(result.status_code)
+        print("Error in sending email : ", result.json())  # print(result.status_code)
     # print(result.json())

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -44,6 +44,7 @@ def payload() -> dict:
             }
         },
         "deciles": False,
+        "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f"),
     }
 
 
@@ -57,8 +58,4 @@ def test_calculate_compare(client, payload, headers):
     assert actual.keys() == expected.keys()
     assert actual["res_brut"] == expected["res_brut"]
     assert actual["total"] == expected["total"]
-    actual_timestamp = datetime.strptime(actual["timestamp"], "%Y-%m-%dT%H:%M:%S.%f%z")
-    expected_timestamp = datetime.strptime(
-        expected["timestamp"], "%Y-%m-%dT%H:%M:%S.%f%z"
-    )
-    assert actual_timestamp < expected_timestamp
+    assert actual["timestamp"] == expected["timestamp"]

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -1,6 +1,6 @@
 from functools import partial
 import json
-
+from datetime import datetime
 import pytest  # type: ignore
 
 
@@ -55,8 +55,10 @@ def test_calculate_compare(client, payload, headers):
     expected = json.loads(response(data=json.dumps(payload_full)).data)
     # Equalizing timestamps, these should not be equal :)
     assert actual.keys() == expected.keys()
-    assert actual['res_brut'] == expected['res_brut']
-    assert actual['total'] == expected['total']
-    actual_timestamp = datetime.strptime(actual['timestamp'], '%Y-%m-%dT%H:%M:%S.%f%z')
-    expected_timestamp = datetime.strptime(expected['timestamp'], '%Y-%m-%dT%H:%M:%S.%f%z')
+    assert actual["res_brut"] == expected["res_brut"]
+    assert actual["total"] == expected["total"]
+    actual_timestamp = datetime.strptime(actual["timestamp"], "%Y-%m-%dT%H:%M:%S.%f%z")
+    expected_timestamp = datetime.strptime(
+        expected["timestamp"], "%Y-%m-%dT%H:%M:%S.%f%z"
+    )
     assert actual_timestamp < expected_timestamp

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -53,5 +53,7 @@ def test_calculate_compare(client, payload, headers):
     payload_full = dict({**payload, "description_cas_types": cas_types})
     actual = json.loads(response(data=json.dumps(payload)).data)
     expected = json.loads(response(data=json.dumps(payload_full)).data)
-
+    # Equalizing timestamps, these should not be equal :)
+    actual.update({"timestamp": ""})
+    expected.update({"timestamp": ""})
     assert actual == expected

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -54,6 +54,9 @@ def test_calculate_compare(client, payload, headers):
     actual = json.loads(response(data=json.dumps(payload)).data)
     expected = json.loads(response(data=json.dumps(payload_full)).data)
     # Equalizing timestamps, these should not be equal :)
-    actual.update({"timestamp": ""})
-    expected.update({"timestamp": ""})
-    assert actual == expected
+    assert actual.keys() == expected.keys()
+    assert actual['res_brut'] == expected['res_brut']
+    assert actual['total'] == expected['total']
+    actual_timestamp = datetime.strptime(actual['timestamp'], '%Y-%m-%dT%H:%M:%S.%f%z')
+    expected_timestamp = datetime.strptime(expected['timestamp'], '%Y-%m-%dT%H:%M:%S.%f%z')
+    assert actual_timestamp < expected_timestamp


### PR DESCRIPTION
- Removes a deprecated endpoint `/calculate/compare_old`
- Adds `timestamp` field in simulation responses
- Style : removes most of prints