### PR TITLE
Quick improve perf

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn --chdir ./server app:app --bind 0.0.0.0:$PORT --workers=3
+web: gunicorn --chdir ./server app:app --bind 0.0.0.0:$PORT --workers=3 --timeout 107
 postdeploy: alembic upgrade head

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn --chdir ./server app:app --bind 0.0.0.0:$PORT --workers=3 --timeout 107
+web: gunicorn --chdir ./server app:app --bind 0.0.0.0:$PORT --workers=3
 postdeploy: alembic upgrade head

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -120,7 +120,7 @@ def compare(period: str, simulation_base, simulation_reform, compute_deciles=Tru
     for simulation, dictionnaire_datagrouped in [simulation_base, simulation_reform]:
         if not kk:
             df = dictionnaire_datagrouped["foyer_fiscal"][["wprm"]]
-        for nomvariable in ["irpp", "nbptr"]:
+        for nomvariable in ["irpp"]:
 
             dictionnaire_datagrouped["foyer_fiscal"][
                 nomvariable
@@ -234,6 +234,8 @@ if not version_beta_sans_simu_pop:
     # DUMMY_DATA = DUMMY_DATA[(DUMMY_DATA["idmen"] > 2500) & (DUMMY_DATA["idmen"] < 7500)]
     print("Dummy Data loaded", len(DUMMY_DATA), "lines")
     simulation_base_deciles = simulation(PERIOD, DUMMY_DATA, TBS)
+    #precalcul cas de base sur la population pour le cache
+    simulation_base_deciles[0].calculate("irpp",PERIOD)
 simulation_base_castypes = simulation(PERIOD, CAS_TYPE, TBS)
 
 

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -234,8 +234,8 @@ if not version_beta_sans_simu_pop:
     # DUMMY_DATA = DUMMY_DATA[(DUMMY_DATA["idmen"] > 2500) & (DUMMY_DATA["idmen"] < 7500)]
     print("Dummy Data loaded", len(DUMMY_DATA), "lines")
     simulation_base_deciles = simulation(PERIOD, DUMMY_DATA, TBS)
-    #precalcul cas de base sur la population pour le cache
-    simulation_base_deciles[0].calculate("irpp",PERIOD)
+    # precalcul cas de base sur la population pour le cache
+    simulation_base_deciles[0].calculate("irpp", PERIOD)
 simulation_base_castypes = simulation(PERIOD, CAS_TYPE, TBS)
 
 


### PR DESCRIPTION
- Précalcul du cas de base (transfère 50% du poids au loading du worker au lieu de la première fois qu'une requête est lancée)
- Retrait de calcul inutile (aide assez peu mais une demi seconde est une demi seconde)
- Retrait du timeout de 107 secondes, car gunicorn n'était qu'un pion dans la conspiration des 30 secondes dont les tentacules s'étendent loin