### PR TITLE
Personnes touchees

### DIFF
--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -215,7 +215,7 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
             "neutre_zero",
             "perdant",
         ]
-        dictionnaire_ff_affectes = {}
+        dictionnaire_ff_affectes: Dict[str, Dict[str, int]] = {}
         for id_comp_1 in range(len(simus_passages)):
             nom_comp_1 = simus_passages[id_comp_1]
             for id_comp_2 in range(id_comp_1 + 1, len(simus_passages)):

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -371,8 +371,8 @@ def scenar_values(
     return df[[var_brute, var_nette]]
 
 
-def from_net_to_brut(val_nette, dataframe_net_to_brut):
-    dfv = dataframe_net_to_brut.values
+def from_net_to_brut(val_nette, dataframe_brut_to_net):
+    dfv = dataframe_brut_to_net.values
     N = len(dfv)
     tt = 1
     while tt < N:
@@ -396,8 +396,8 @@ def from_net_to_brut(val_nette, dataframe_net_to_brut):
     return lambda_ * apresx + (1 - lambda_) * avantx
 
 
-def from_brut_to_net(val_brute, dataframe_net_to_brut):
-    dfv = dataframe_net_to_brut.values
+def from_brut_to_net(val_brute, dataframe_brut_to_net):
+    dfv = dataframe_brut_to_net.values
     N = len(dfv)
     tt = 1
     while tt < N:

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -216,30 +216,35 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
             "perdant",
         ]
         dictionnaire_ff_affectes: Dict[str, Dict[str, int]] = {}
+        IMPOT_DIMINUE = 1
+        IMPOT_INCHANGE = 0
+        IMPOT_AUGMENTE = -1
+        IMPOT_NUL_DELTA = -2
+
         for id_comp_1 in range(len(simus_passages)):
             nom_comp_1 = simus_passages[id_comp_1]
             for id_comp_2 in range(id_comp_1 + 1, len(simus_passages)):
                 nom_comp_2 = simus_passages[id_comp_2]
                 nom_colonne_affectation = "{}_to_{}".format(nom_comp_1, nom_comp_2)
                 dictionnaire_ff_affectes[nom_colonne_affectation] = {}
-                impots_par_reforme[nom_colonne_affectation] = 0
+                impots_par_reforme[nom_colonne_affectation] = IMPOT_INCHANGE
                 impots_par_reforme.loc[
                     (
                         impots_par_reforme[nom_comp_1] - 0.1
                         > impots_par_reforme[nom_comp_2]
                     ),
                     nom_colonne_affectation,
-                ] = -1
+                ] = IMPOT_AUGMENTE
                 impots_par_reforme.loc[
                     (
                         impots_par_reforme[nom_comp_1] + 0.1
                         < impots_par_reforme[nom_comp_2]
                     ),
                     nom_colonne_affectation,
-                ] = 1
+                ] = IMPOT_DIMINUE
                 impots_par_reforme.loc[
                     (impots_par_reforme[nom_comp_1]) > -0.01, nom_colonne_affectation
-                ] = (impots_par_reforme[nom_colonne_affectation] - 2)
+                ] = (impots_par_reforme[nom_colonne_affectation] + IMPOT_NUL_DELTA)
                 # Ca nous amene à : -3 si (avant=0, plf !=0) , -2 si (avant=0, plf=0), -1 si (avant!=0 et perdant),
                 # 0 si (avant!=0 et ni gagnant ni perdant), 1 si (avant!=0 et gagnant)
                 # Oui, c'est ca que ca veut dire le transcription_code

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -139,9 +139,10 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
         impots_par_reforme[nom_simulation] = dictionnaire_simulations[nom_simulation][
             0
         ].calculate("irpp", period)
-        impots_par_reforme["rfr"] = dictionnaire_simulations[nom_simulation][
-            0
-        ].calculate("rfr", period)
+        if compute_deciles:
+            impots_par_reforme["rfr"] = dictionnaire_simulations[nom_simulation][
+                0
+            ].calculate("rfr", period)
 
     for nom_res_base in [
         colonne_df

--- a/server/handlers/cas_types.py
+++ b/server/handlers/cas_types.py
@@ -38,6 +38,8 @@ class SimulationRunner(object):
         dct = None
         if "description_cas_types" in dbod:
             dct = dbod["description_cas_types"]
+            if not len(dct):
+                return error_as_dict("Empty list of cas types received"), 200
         if "reforme" not in dbod:
             return error_as_dict("missing 'reforme' field in body of your request"), 200
         dic_resultat = CompareOldNew(
@@ -54,12 +56,13 @@ class SimulationRunner(object):
             return Response(
                 json.dumps(
                     error_as_dict("missing 'reforme' field in body of your request")
-                ), status=200
+                ),
+                status=200,
             )
         if "token" not in dbod:
             return Response(
                 json.dumps(error_as_dict("missing token: necessary for this request")),
-                status=200
+                status=200,
             )
         CU = check_user(session, dbod["token"])
         if CU["success"] is False:
@@ -68,6 +71,9 @@ class SimulationRunner(object):
             return Response(
                 json.dumps(
                     error_as_dict("bad request, no description_cas_types should appear")
-                ), status=200
+                ),
+                status=200,
             )
-        return Response(simpop_stream(dbod), status=200, content_type="application/json")
+        return Response(
+            simpop_stream(dbod), status=200, content_type="application/json"
+        )

--- a/tests/Simulation_engine/test_simulate_pop_from_reform.py
+++ b/tests/Simulation_engine/test_simulate_pop_from_reform.py
@@ -250,10 +250,26 @@ def test_sim_pop_dict_content(reform):
     comp_result = compare(PERIOD, {"apres": simulation_reform})
     assert "total" in comp_result
     assert "deciles" in comp_result
+    assert "frontieres_deciles" in comp_result
+    assert len(comp_result["frontieres_deciles"]) == len(comp_result["deciles"])
+    assert "foyers_fiscaux_touches" in comp_result
     # assert len(comp_result["deciles"])==10 Removed cause with the cas type description
     for key in ["avant", "apres", "plf"]:
         assert key in comp_result["total"]
         assert key in comp_result["deciles"][0]
+    for key in ["avant_to_apres", "avant_to_plf", "plf_to_apres"]:
+        assert key in comp_result["foyers_fiscaux_touches"]
+        for type_touche, nb_people in comp_result["foyers_fiscaux_touches"][
+            key
+        ].items():
+            assert type_touche in [
+                "gagnant",
+                "neutre",
+                "perdant",
+                "perdant_zero",
+                "neutre_zero",
+            ]
+            assert isinstance(nb_people, int)
 
 
 def test_sim_base_cas_types_dict_content_ok(reform):


### PR DESCRIPTION
Nombre de foyers fiscaux touchés.

C'est un WIP dans le sens où ça sort juste le résultat total. Le format est à discuter, mais en tout cas la PR sera là pour des futurs tests.

Exemple de résultat. notez les deux catégories "neutre_zero" et "neutre" qui représentent des foyers fiscaux qui ne sont pas affectés par la réforme, les uns parce qu'ils ne payent pas d'impot sur le revenu avec le code existant, les autres parce qu'ils ont un revenu élevé.

    "foyers_fiscaux_touches": {
        "avant_to_plf": {
            "neutre_zero": 20827169,
            "neutre": 559220,
            "gagnant": 16502792
        },
        "avant_to_apres": {
            "neutre_zero": 20827169,
            "neutre": 559220,
            "gagnant": 16502792
        },
        "plf_to_apres": {
            "neutre_zero": 20838054,
            "neutre": 17051127
        }
    }