### PR TITLE
[WIP] Update 2020

### DIFF
--- a/Simulation_engine/agg_pop.py
+++ b/Simulation_engine/agg_pop.py
@@ -1,4 +1,3 @@
-
 import pandas  # type: ignore
 import os
 import math
@@ -279,7 +278,7 @@ def test_h5_input(
     name_variables=("rfr", "irpp", "nbptr"),
     aggfunc="sum",
     compdic=None,
-    is_plf=False
+    is_plf=False,
 ):
     PERIOD = "2018"
     TBS = TBS_PLF if is_plf else FranceTaxBenefitSystem()
@@ -290,7 +289,9 @@ def test_h5_input(
     )
     if aggfunc == "sum":  # Pour la somme, on calcule les % d'erreur sur la répartition.
         testerrorvalues(df)
-    aggs_to_compute = ["wprm", "salaire_de_base", "retraite_brute"] + list(name_variables)
+    aggs_to_compute = ["wprm", "salaire_de_base", "retraite_brute"] + list(
+        name_variables
+    )
     val_donnees_pac_agg = 0
     trpac_agg = [
         compdic[ag]
@@ -598,7 +599,7 @@ def anotherexample():
         name_variables=("rfr", "irpp", "nbptr"),
         aggfunc="sum",
         compdic=theoric_values["sum"],
-        is_plf=False
+        is_plf=False,
     )
     print("after adj 2 :")
     test_h5_input(
@@ -606,7 +607,7 @@ def anotherexample():
         name_variables=("rfr", "irpp", "nbptr"),
         aggfunc="sum",
         compdic=theoric_values["sum"],
-        is_plf=False
+        is_plf=False,
     )
 
     print("WITH PLF NOW HIhihi")
@@ -616,7 +617,7 @@ def anotherexample():
         name_variables=("rfr", "irpp", "nbptr"),
         aggfunc="sum",
         compdic=theoric_values["sum"],
-        is_plf=True
+        is_plf=True,
     )
     print("after adj 2 plf:")
     test_h5_input(
@@ -624,8 +625,9 @@ def anotherexample():
         name_variables=("rfr", "irpp", "nbptr"),
         aggfunc="sum",
         compdic=theoric_values["sum"],
-        is_plf=True
+        is_plf=True,
     )
+
 
 # ToDo : Le test doit retourner True si :
 #  - On a Une erreur totale sur la distrib de rfr < 2.5% après ajustement

--- a/Simulation_engine/reformePLF.py
+++ b/Simulation_engine/reformePLF.py
@@ -88,7 +88,7 @@ only_reforme = {
 }
 
 
-reformePLF = {
+reforme_PLF_2020 = {
     "impot_revenu": {
         "bareme": {
             "seuils": [10064, 25659, 73369, 157806],

--- a/Simulation_engine/reformePLF.py
+++ b/Simulation_engine/reformePLF.py
@@ -1,4 +1,3 @@
-
 reforme_base = {
     "impot_revenu": {
         "bareme": {

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -22,7 +22,7 @@ nom_table_resultats_base = os.getenv("NAME_TABLE_BASE_RESULT")  # type: Optional
 if nom_table_resultats_base is None:
     nom_table_resultats_base = "base_results"
 
-version_beta_sans_simu_pop = not (data_path is None)  # #Si DATA_PATH n'est pas renseigné dans .env, on lance sans simpop
+version_beta_sans_simu_pop = (data_path is None)  # #Si DATA_PATH n'est pas renseigné dans .env, on lance sans simpop
 adjust_results = True
 
 # Decrit les réformes renvoyées par défaut.

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -30,7 +30,7 @@ adjust_results = True
 # Toutes les requêtes renvoient un résultat "avant" (code existant),
 # un résultat "apres" (reforme renseignée dans la requete)
 # et un résultat par réforme présente dans reformes_par_defaut
-reformes_par_defaut: Dict[str,Dict] = {}
+reformes_par_defaut: Dict[str, Dict] = {}
 # from Simulation_engine.reformePLF import reforme_PLF_2020
 # reformes_par_defaut["plf"] = reforme_PLF_2020  Ca c'était le PLF 2020. Moins intéressant depuis qu'il est la loi
 
@@ -645,6 +645,7 @@ def texte_cas_types(data=None):
     for k in data["idfoy"].values:
         dic_res[k] = foyertotexte(k, data)
     return dic_res
+
 
 def simulation_from_cas_types(descriptions):
     df = dataframe_from_cas_types_description(descriptions)

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -142,7 +142,9 @@ def simulation(period, data, tbs):
 
 def calcule_personnes_touchees(impots_par_reforme):
     # On fait tous les passages possibles entre les resultats:
-    simus_passages = ["avant", "plf", "apres"]
+    simus_passages = sorted(list(TBS_DEFAULT.keys())) + [
+        "apres"
+    ]  # ["avant", "plf", "apres"]
     transcription_code = ["neutre", "gagnant", "perdant_zero", "neutre_zero", "perdant"]
     foyers_fiscaux_touches: Dict[str, Dict[str, int]] = {}
     IMPOT_DIMINUE = 1

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -22,7 +22,9 @@ nom_table_resultats_base = os.getenv("NAME_TABLE_BASE_RESULT")  # type: Optional
 if nom_table_resultats_base is None:
     nom_table_resultats_base = "base_results"
 
-version_beta_sans_simu_pop = (data_path is None)  # #Si DATA_PATH n'est pas renseigné dans .env, on lance sans simpop
+version_beta_sans_simu_pop = (
+    data_path is None
+)  # #Si DATA_PATH n'est pas renseigné dans .env, on lance sans simpop
 adjust_results = True
 
 # Decrit les réformes renvoyées par défaut.
@@ -217,7 +219,9 @@ def compare(period: str, dictionnaire_simulations, compute_deciles=True):
         # On en a besoin si ces colonnes ne sont pas déjà dans le dictionnaire_simulations (par exemple
         # dans le cas d'un compare avec isdecile = True)
         frontieres_deciles: List[float] = []
-        noms_simus = list(set(dictionnaire_simulations.keys()) | set(TBS_DEFAULT.keys()))
+        noms_simus = list(
+            set(dictionnaire_simulations.keys()) | set(TBS_DEFAULT.keys())
+        )
         totweight = impots_par_reforme["wprm"].sum()
         nbd = 10
         decilweights = [i / nbd * totweight for i in range(nbd + 1)]
@@ -355,7 +359,7 @@ def calcule_maillage_intervalle(
 
 
 def scenar_values(
-    minv, maxv, var_brute, var_nette, pourcentage_hausse=0.01, valeur_hausse=100
+    minv, maxv, var_brute, var_nette, pourcentage_hausse=0.001, valeur_hausse=100
 ):
     """
     Calcule les valeurs de var_nette pour var_brute dans [minv, maxv]
@@ -433,9 +437,11 @@ conversion_variables["retraite_brute_to_retraite_imposable"] = scenar_values(
 
 PERIOD = str(annee_de_calcul)
 TBS = FranceTaxBenefitSystem()
-TBS_DEFAULT = {"avant" : TBS}
+TBS_DEFAULT = {"avant": TBS}
 for nom_reforme in reformes_par_defaut:
-    TBS_DEFAULT[nom_reforme] = IncomeTaxReform(TBS, reformes_par_defaut[nom_reforme], PERIOD)
+    TBS_DEFAULT[nom_reforme] = IncomeTaxReform(
+        TBS, reformes_par_defaut[nom_reforme], PERIOD
+    )
 CAS_TYPE = load_data("DCT.csv")
 # SIMCAT = partial(simulation, period=PERIOD, data=CAS_TYPE)   unused??
 # SIMCAT_BASE = SIMCAT(tbs=TBS)
@@ -471,12 +477,18 @@ if not version_beta_sans_simu_pop:
         # precalcul cas de base sur la population pour le cache
         simulations_reformes_par_defaut_deciles = {}
         for nom_reforme in TBS_DEFAULT:
-            simulations_reformes_par_defaut_deciles[nom_reforme] = simulation(PERIOD, DUMMY_DATA, TBS_DEFAULT[nom_reforme])
-            resultats_de_basenom_reforme = simulations_reformes_par_defaut_deciles[nom_reforme].calculate("irpp", PERIOD)
+            simulations_reformes_par_defaut_deciles[nom_reforme] = simulation(
+                PERIOD, DUMMY_DATA, TBS_DEFAULT[nom_reforme]
+            )
+            resultats_de_basenom_reforme = simulations_reformes_par_defaut_deciles[
+                nom_reforme
+            ].calculate("irpp", PERIOD)
 # simulation_base_castypes = simulation(PERIOD, CAS_TYPE, TBS)
 simulations_reformes_par_defaut_castypes = {}
 for nom_reforme in TBS_DEFAULT:
-    simulations_reformes_par_defaut_castypes[nom_reforme] = simulation(PERIOD, CAS_TYPE, TBS_DEFAULT[nom_reforme])
+    simulations_reformes_par_defaut_castypes[nom_reforme] = simulation(
+        PERIOD, CAS_TYPE, TBS_DEFAULT[nom_reforme]
+    )
 
 
 def foyertosomethingelse(idfoy):
@@ -649,7 +661,13 @@ def texte_cas_types(data=None):
 
 def simulation_from_cas_types(descriptions):
     df = dataframe_from_cas_types_description(descriptions)
-    return (df, {nom_reforme : simulation(PERIOD, df, reforme) for nom_reforme, reforme in TBS_DEFAULT.items()})
+    return (
+        df,
+        {
+            nom_reforme: simulation(PERIOD, df, reforme)
+            for nom_reforme, reforme in TBS_DEFAULT.items()
+        },
+    )
 
 
 # Transforme une description de cas types en un dataframe parsable. Good luck!
@@ -893,8 +911,4 @@ def CompareOldNew(taux=None, isdecile=True, dictreform=None, castypedesc=None):
             }
         }
 
-    return compare(
-        PERIOD,
-        default_sims,
-        isdecile,
-    )
+    return compare(PERIOD, default_sims, isdecile)

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -364,12 +364,12 @@ def scenar_values(
     df = calcule_maillage_intervalle(
         var_brute, minv, maxv, pourcentage_hausse, valeur_hausse
     )
-    PERIOD = "2018"
+    PERIOD = str(annee_de_calcul)
     TBS = FranceTaxBenefitSystem()
     # définit un ménage par ligne
     sim = simulation(PERIOD, df, TBS)
     net = var_nette
-    df[net] = sim[0].calculate_add(net, "2018")
+    df[net] = sim[0].calculate_add(net, PERIOD)
     return df[[var_brute, var_nette]]
 
 

--- a/Simulation_engine/simulate_pop_from_reform.py
+++ b/Simulation_engine/simulate_pop_from_reform.py
@@ -30,7 +30,7 @@ adjust_results = True
 # Toutes les requêtes renvoient un résultat "avant" (code existant),
 # un résultat "apres" (reforme renseignée dans la requete)
 # et un résultat par réforme présente dans reformes_par_defaut
-reformes_par_defaut = {}
+reformes_par_defaut: Dict[str,Dict] = {}
 # from Simulation_engine.reformePLF import reforme_PLF_2020
 # reformes_par_defaut["plf"] = reforme_PLF_2020  Ca c'était le PLF 2020. Moins intéressant depuis qu'il est la loi
 
@@ -646,10 +646,9 @@ def texte_cas_types(data=None):
         dic_res[k] = foyertotexte(k, data)
     return dic_res
 
-
 def simulation_from_cas_types(descriptions):
     df = dataframe_from_cas_types_description(descriptions)
-    return (df, {nom_reforme : simulation(PERIOD, df, reforme) for nom_reforme, reforme in TBS_DEFAULT})
+    return (df, {nom_reforme : simulation(PERIOD, df, reforme) for nom_reforme, reforme in TBS_DEFAULT.items()})
 
 
 # Transforme une description de cas types en un dataframe parsable. Good luck!

--- a/scripts/generate_default_results.py
+++ b/scripts/generate_default_results.py
@@ -17,7 +17,9 @@ def generate_default_results():
     liste_base_reformes = []
     for reforme in TBS_DEFAULT:
         liste_base_reformes += [reforme]
-        bulk_data_simulation, data_by_entity = simulation(PERIOD, DUMMY_DATA, TBS_DEFAULT[reforme])
+        bulk_data_simulation, data_by_entity = simulation(
+            PERIOD, DUMMY_DATA, TBS_DEFAULT[reforme]
+        )
         if base_results is None:
             base_results = data_by_entity["foyer_fiscal"][["wprm", "idfoy"]]
         base_results[reforme] = bulk_data_simulation.calculate("irpp", PERIOD)

--- a/scripts/generate_default_results.py
+++ b/scripts/generate_default_results.py
@@ -20,7 +20,7 @@ def generate_default_results():
         bulk_data_simulation, data_by_entity = simulation(PERIOD, DUMMY_DATA, TBS_DEFAULT[reforme])
         if base_results is None:
             base_results = data_by_entity["foyer_fiscal"][["wprm", "idfoy"]]
-        base_results[reforme]=bulk_data_simulation.calculate("irpp", PERIOD)
+        base_results[reforme] = bulk_data_simulation.calculate("irpp", PERIOD)
     base_results[["idfoy"] + liste_base_reformes + ["wprm"]].to_csv(
         "base_results.csv", index=False
     )

--- a/scripts/generate_default_results.py
+++ b/scripts/generate_default_results.py
@@ -1,8 +1,7 @@
 from Simulation_engine.simulate_pop_from_reform import (
     simulation,
     PERIOD,
-    TBS,
-    TBS_PLF,
+    TBS_DEFAULT,
     DUMMY_DATA,
 )
 
@@ -13,15 +12,16 @@ from Simulation_engine.simulate_pop_from_reform import (
 
 
 def generate_default_results():
-    # Keeping computations short with option to keep file under 1000 FF
-    # DUMMY_DATA = DUMMY_DATA[(DUMMY_DATA["idmen"] > 2500) & (DUMMY_DATA["idmen"] < 7500)]
-    bulk_data_simulation, data_by_entity = simulation(PERIOD, DUMMY_DATA, TBS)
     # precalcul cas de base sur la population pour le cache
-    base_results = data_by_entity["foyer_fiscal"][["wprm", "idfoy"]]
-    base_results["avant"] = bulk_data_simulation.calculate("irpp", PERIOD)
-    simulation_plf_deciles = simulation(PERIOD, DUMMY_DATA, TBS_PLF)
-    base_results["plf"] = simulation_plf_deciles[0].calculate("irpp", PERIOD)
-    base_results[["idfoy", "avant", "plf", "wprm"]].to_csv(
+    base_results = None
+    liste_base_reformes = []
+    for reforme in TBS_DEFAULT:
+        liste_base_reformes += [reforme]
+        bulk_data_simulation, data_by_entity = simulation(PERIOD, DUMMY_DATA, TBS_DEFAULT[reforme])
+        if base_results is None:
+            base_results = data_by_entity["foyer_fiscal"][["wprm", "idfoy"]]
+        base_results[reforme]=bulk_data_simulation.calculate("irpp", PERIOD)
+    base_results[["idfoy"] + liste_base_reformes + ["wprm"]].to_csv(
         "base_results.csv", index=False
     )
     return base_results

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "gunicorn >= 19.0.0, < 20.0.0",
         "mailjet-rest >= 1.3.3, < 2.0.0",
         "openfisca-core >= 34.2.8, < 35.0.0",
-        "openfisca-france >= 48.2.0, < 49.0.0",
+        "openfisca-france >= 48.10.6, < 49.0.0",
         "pandas >= 0.24.0, < 0.25.0",
         "psycopg2 >= 2.8.3, < 3.0.0",
         "pyjwt >= 1.7.1, < 2.0.0",

--- a/tests/Simulation_engine/test_simulate_pop_from_reform.py
+++ b/tests/Simulation_engine/test_simulate_pop_from_reform.py
@@ -18,10 +18,9 @@ from Simulation_engine.simulate_pop_from_reform import (  # type: ignore
     IncomeTaxReform,
     PERIOD,
     simulation,
-    simulation_base_castypes,
+    simulations_reformes_par_defaut_castypes,
     CompareOldNew,
     simulation_from_cas_types,
-    simulation_plf_castypes,
     TBS,
 )
 
@@ -274,13 +273,11 @@ def test_sim_pop_dict_content(reform):
 
 def test_sim_base_cas_types_dict_content_ok(reform):
     simulation_reform = simulation(PERIOD, CAS_TYPE, reform)
+    simulations_cas_types = simulations_reformes_par_defaut_castypes
+    simulations_cas_types["apres"] = simulation_reform
     comp_result = compare(
         PERIOD,
-        {
-            "avant": simulation_base_castypes,
-            "plf": simulation_plf_castypes,
-            "apres": simulation_reform,
-        },
+        simulations_cas_types,
         compute_deciles=False,
     )
     assert "total" in comp_result

--- a/tests/server/handlers/test_cas_types.py
+++ b/tests/server/handlers/test_cas_types.py
@@ -49,6 +49,8 @@ def payload() -> dict:
 
 
 def test_calculate_compare_with_cas_types(client, payload, headers):
+    # Vérifie qu'une simulation qui ne contient pas les cas types renvoie les mêmes résultats
+    # qu'une simulation avec les cas-types par défaut
     cas_types = json.loads(client.post("metadata/description_cas_types").data)
     response = partial(client.post, "calculate/compare", headers=headers)
     payload_full = dict({**payload, "description_cas_types": cas_types})
@@ -57,9 +59,6 @@ def test_calculate_compare_with_cas_types(client, payload, headers):
     expected = json.loads(response(data=json.dumps(payload_full)).data)
 
     assert actual.keys() == expected.keys()
-    for var_in_res_brut in ["avant", "apres", "plf"]:
-        assert var_in_res_brut in expected["res_brut"]
-        assert var_in_res_brut in expected["total"]
 
     assert actual["res_brut"] == expected["res_brut"]
     assert actual["total"] == expected["total"]
@@ -67,10 +66,11 @@ def test_calculate_compare_with_cas_types(client, payload, headers):
 
 
 def test_calculate_compare_weights(client, payload, headers):
+    # Vérifie que les cas types des résultats apparaissent tous dans tous les champs
     response = partial(client.post, "calculate/compare", headers=headers)
     actual = json.loads(response(data=json.dumps(payload)).data)
 
-    for var_in_res_brut in ["avant", "apres", "plf"]:
+    for var_in_res_brut in actual["res_brut"].keys():
         assert set(actual["res_brut"]["wprm"].keys()) == set(
             actual["res_brut"][var_in_res_brut].keys()
         )


### PR DESCRIPTION
Retire le PLF par défaut + quelques modifications de structure pour pouvoir le rebrancher facilement.

Je subodore que pas mal de tests devront être changés, voyons ce que nous raconte CircleCI

Reste à faire : 
- changer la version d'Openfisca_france utilisée (oui bon ça ca va pas mal handicaper les tests tant que la nouvelle version est pas en prod)